### PR TITLE
Fixes 2 issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docker-compose.yml
 ids.lst
 seahub_settings_template.py
 seafile/custom
+nginx/certs/

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -25,8 +25,8 @@ seafile:
   volumes_from:
     - data
   environment:
-    ENABLE_BACKUP: False
-    ENABLE_GARBAGE_COLLECTION: False
+    ENABLE_BACKUP: 'False'
+    ENABLE_GARBAGE_COLLECTION: 'False'
     SEAFILE_VERSION: 5.0.4
     SEAFILE_DB_USER: seafile
     SEAFILE_DB_PASSWORD: password

--- a/docker-compose.yml.example.apache
+++ b/docker-compose.yml.example.apache
@@ -25,8 +25,8 @@ seafile:
   volumes_from:
     - data
   environment:
-    ENABLE_BACKUP: False
-    ENABLE_GARBAGE_COLLECTION: False
+    ENABLE_BACKUP: 'False'
+    ENABLE_GARBAGE_COLLECTION: 'False'
     SEAFILE_VERSION: 5.0.4
     SEAFILE_DB_USER: seafile
     SEAFILE_DB_PASSWORD: password

--- a/docker-compose.yml.example.apache_shibboleth
+++ b/docker-compose.yml.example.apache_shibboleth
@@ -25,8 +25,8 @@ seafile:
   volumes_from:
     - data
   environment:
-    ENABLE_BACKUP: False
-    ENABLE_GARBAGE_COLLECTION: False
+    ENABLE_BACKUP: 'False'
+    ENABLE_GARBAGE_COLLECTION: 'False'
     SEAFILE_VERSION: 5.0.4
     SEAFILE_DB_USER: seafile
     SEAFILE_DB_PASSWORD: password

--- a/docker-compose.yml.example.nginx
+++ b/docker-compose.yml.example.nginx
@@ -25,8 +25,8 @@ seafile:
   volumes_from:
     - data
   environment:
-    ENABLE_BACKUP: False
-    ENABLE_GARBAGE_COLLECTION: False
+    ENABLE_BACKUP: 'False'
+    ENABLE_GARBAGE_COLLECTION: 'False'
     SEAFILE_VERSION: 5.0.4
     SEAFILE_DB_USER: seafile
     SEAFILE_DB_PASSWORD: password

--- a/docker-compose.yml.example.pro.nginx
+++ b/docker-compose.yml.example.pro.nginx
@@ -25,8 +25,8 @@ seafile:
   volumes_from:
     - data
   environment:
-    ENABLE_BACKUP: False
-    ENABLE_GARBAGE_COLLECTION: False
+    ENABLE_BACKUP: 'False'
+    ENABLE_GARBAGE_COLLECTION: 'False'
     SEAFILE_VERSION: 5.0.5
     SEAFILE_DB_USER: seafile
     SEAFILE_DB_PASSWORD: password


### PR DESCRIPTION
The nginx/certs dir wasn't in the `.gitignore` which means `git add -A` causes files inside of that dir to be added to git.

`False` isn't valid anymore in ENV fields with docker-compose, instead booleans need to be wrapped in quotes.